### PR TITLE
Specify exact package versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,18 +13,41 @@ permissions:
   contents: read  # to fetch code
 
 jobs:
-  build:
-    name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+  built-latest:
+    name: Latest packages (${{ matrix.os }} Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         include:
-        - os: macOS-11
-          python-version: "3.11"
         - os: windows-2019
           python-version: "3.11"
+
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # ratchet:actions/checkout@v4
+      with:
+        submodules: true
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # ratchet:actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+        pip install -U jax flax optax orbax
+    - name: Run tests
+      run: |
+        pytest -n auto jax_ml_stack
+
+  build:
+    name: Pinned packages (${{ matrix.os }} Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # ratchet:actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info
 Pipfile
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,10 @@ keywords = []
 
 # pip dependencies of the project
 dependencies = [
-    "jax",
-    "flax",
-    "optax",
+    "jax==0.4.31",
+    "flax==0.8.5",
+    "optax==0.2.3",
+    "orbax==0.1.9",
 ]
 
 [project.urls]


### PR DESCRIPTION
This adds a "latest" build that tests the latest releases of the core packages.

This obviously depends on the state of upstream packages, but it should catch issues before new releases. We should also probably have a build (maybe nightly?) against the upstream versions of each package