### PR TITLE
Add grain test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ on:
 permissions:
   contents: read  # to fetch code
 
+# TODO(jakevdp): add testing on macOS-11 and windows-2019 when grain supports them,
+# or alternatively run a subset of tests without grain.
 jobs:
   built-latest:
     name: Latest packages (${{ matrix.os }} Python ${{ matrix.python-version }})
@@ -20,9 +22,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.10", "3.11", "3.12"]
-        include:
-        - os: windows-2019
-          python-version: "3.11"
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # ratchet:actions/checkout@v4
@@ -35,8 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev,tfds]
-        pip install -U jax flax optax orbax tensorflow tensorflow_datasets
+        pip install -U jax flax grain optax orbax tensorflow tensorflow_datasets pytest pytest-xdist
     - name: Run tests
       run: |
         pytest -n auto jax_ml_stack
@@ -60,7 +58,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev,tfds]
+        pip install .[dev,tfds,grain]
     - name: Run tests
       run: |
         pytest -n auto jax_ml_stack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ keywords = []
 dependencies = [
     "jax==0.4.31",
     "flax==0.8.5",
+    "grain==0.2.0",
     "optax==0.2.3",
     "orbax==0.1.9",
 ]
@@ -33,9 +34,16 @@ dev = [
     "pytest",
     "pytest-xdist",
 ]
+
+# TensorFlow datasets is an extra because it has a large install footprint.
 tfds = [
     "tensorflow==2.17.0",
     "tensorflow_datasets==4.9.6",
+]
+
+# Grain is an extra because as of v0.2.0 it has no OSX wheels.
+grain = [
+    "grain==0.2.0",
 ]
 
 [tool.pyink]


### PR DESCRIPTION
`grain` has no OSX-compatible installations, so we probably shouldn't add it yet, but I wanted to try this out.