### PR TITLE
Fix flax test for flax v0.9.0

### DIFF
--- a/jax_ml_stack/tests/test_nnx_with_optax.py
+++ b/jax_ml_stack/tests/test_nnx_with_optax.py
@@ -46,7 +46,7 @@ class NNXOptaxTest(unittest.TestCase):
       return jnp.mean((model(x) - y) ** 2)
 
     initial_loss = loss(model)
-    grads = nnx.grad(loss, wrt=nnx.Param)(state.model)
+    grads = nnx.grad(loss)(state.model)
     state.update(grads)
     final_loss = loss(model)
 


### PR DESCRIPTION
the `nnx.grad` API has changed (in a way that I believe is backward-compatible)